### PR TITLE
Use freshly build bootloader in merged firmware

### DIFF
--- a/software/merge_firmware_hook.py
+++ b/software/merge_firmware_hook.py
@@ -58,7 +58,7 @@ env.AddPostAction(
         "--flash_size", flash_size,
         "--flash_freq", "40m",
         "--target-offset", "0x1000",
-        "0x1000", "bootloader_dio_40m.bin",
+        "0x1000", env.subst("$BUILD_DIR/bootloader.bin"),
         "0x8000", env.subst("$BUILD_DIR/partitions.bin"),
         "0xd000", env.subst("$BUILD_DIR/firmware_info.bin"),
         "0xe000", "boot_app0.bin",


### PR DESCRIPTION
Use the bootloader.bin that is freshly build to avoid problems flashing to different platforms.