### PR TITLE
rtc: Don't attempt to render if no RTC bricklet is connected.

### DIFF
--- a/software/web/src/modules/rtc/main.tsx
+++ b/software/web/src/modules/rtc/main.tsx
@@ -91,7 +91,7 @@ export class Rtc extends ConfigComponent<'rtc/config', {}, RtcPageState> {
 
 
     render(props: {}, state: RTCConfig & RtcPageState) {
-        if (!util.render_allowed())
+        if (!util.render_allowed() || !API.get("info/modules").rtc)
             return <></>
 
         return <>


### PR DESCRIPTION
The webinterface is not working correctly w/o an RTC bricklet...