### PR TITLE
meter: fix api_meter not updating last_value_change

### DIFF
--- a/software/src/modules/meter/meter.cpp
+++ b/software/src/modules/meter/meter.cpp
@@ -136,7 +136,17 @@ void Meter::updateMeterAllValues(int idx, float val)
     if (!meter_setup_done)
         return;
 
-    all_values.get(idx)->updateFloat(val);
+    bool changed = false;
+
+    if (!isnan(val)) {
+        auto wrap = all_values.get(idx);
+        auto old_value = wrap->asFloat();
+        changed |= wrap->updateFloat(val) && !isnan(old_value);
+    }
+
+    if (changed) {
+        last_value_change = now_us();
+    }
 }
 
 void Meter::updateMeterAllValues(float values[METER_ALL_VALUES_COUNT])


### PR DESCRIPTION
"meter/all_values_update" calls `Meter::updateMeterAllValues(int idx, float val) {...]`.
Unfortunately last_value_change is not updated, resulting in meter monitoring blocking after some time without charging.