### PR TITLE
ev: Announce ev feature

### DIFF
--- a/software/src/modules/ev/ev.cpp
+++ b/software/src/modules/ev/ev.cpp
@@ -184,6 +184,7 @@ void Ev::pre_setup()
 
 void Ev::setup()
 {
+    api.addFeature("ev");
     api.restorePersistentConfig("ev/config", &config);
     initialized = true;
 }


### PR DESCRIPTION
This announces the ev module in `info/features`, analogous to how other modules (evse, meters, nfc, phase_switch, ...) advertise their availability.

## Motivation

evcc is adding WARP4 support including reading the vehicle SoC and MAC address from the `ev/state` API (see evcc-io/evcc#31446). evcc detects optional WARP functionality at runtime via `GET /info/features`, which works for all APIs it consumes except `ev/state`: the ev module currently registers no feature, so evcc would have to probe the endpoint and treat a failure as "not available". That cannot distinguish a device without the ev module from a transient error. The evcc maintainer asked whether the module could be announced as a feature instead (evcc-io/evcc#31446 (comment): https://github.com/evcc-io/evcc/pull/31446#discussion_r3522847936), so feature detection stays consistent.

## Change

- `Ev::setup()` calls `api.addFeature("ev")`, following the convention of other software-only modules (em_common, nfc_bricklet).

Since the ev module is currently only part of the WARP4 build, the "ev" feature also identifies WARP4 devices with ISO 15118 vehicle data support. The typed `feature` union in `web/src/ts/api.ts` is intentionally left untouched since the web frontend does not check this feature itself (same as front_panel, ocpp_debug, evse_gp_output).

The evcc PR will switch to feature-based detection once this is released.

/cc @rtrbt (you were already pinged in the evcc PR)