### PR TITLE
iso15118: Reject V2GTP frames shorter than the header

### DIFF
--- a/software/src/modules/iso15118/common.cpp
+++ b/software/src/modules/iso15118/common.cpp
@@ -396,6 +396,14 @@ void Common::send_exi(ExiType type)
 
 void Common::decode(uint8_t *data, const size_t length)
 {
+    // A short frame would underflow the payload size below (exi_bitstream_init).
+    // The header checks that follow might not catch it as exi_data is a shared buffer
+    // and the bytes might hold valid data from a previous response we sent.
+    if (length < sizeof(V2GTP_Header)) {
+        iso15118.trace("Common: Truncated V2GTP header: %zu bytes", length);
+        return;
+    }
+
     V2GTP_Header *header = reinterpret_cast<V2GTP_Header*>(data);
     if(header->protocol_version != 0x01) {
         iso15118.trace("Common: Invalid protocol version: %d", header->protocol_version);


### PR DESCRIPTION
Common::decode currently computes the EXI payload size as length - sizeof(V2GTP_Header).

`length` is passed in to the function and taken as is. It's what comes of "the wire".
`sizeof(V2GTP_Header)` is 8 bytes, so if `length` is smaller than 8  it'll be (for example) 0 - 8 which underflows to more or less `SIZE_MAX` and that is then passed in to `exi_bitstream_init` as the buffer size.
In theory this could lead to the decoder reading past the allocated buffer.