### PR TITLE
iso15118: Add OUI of the Bosch OBC in the VW ID.7

### DIFF
--- a/software/src/modules/iso15118/common.cpp
+++ b/software/src/modules/iso15118/common.cpp
@@ -60,6 +60,7 @@ static constexpr EVCCVendorOUI evcc_vendor_ouis[] = {
     {{0x70, 0xB3, 0xD6}, EVCCVendor::Audi},
     {{0x18, 0x4C, 0xAE}, EVCCVendor::Aumovio},      // OBC seen in Renault Megane E-Tech
     {{0x00, 0x01, 0xA9}, EVCCVendor::BMW},
+    {{0x10, 0xBD, 0x43}, EVCCVendor::Bosch},        // OBC seen in VW ID.7
     {{0x38, 0x1F, 0x26}, EVCCVendor::Bosch},        // OBC seen in Citroën e-C3
     {{0x48, 0x31, 0x33}, EVCCVendor::Bosch},
     {{0xEC, 0xFA, 0x03}, EVCCVendor::FCA},


### PR DESCRIPTION
I'm currently testing my new VW ID.7 (model year 2027, ID software 6.0.0) with a Warp Charger 4 Pro.

Things I found so far is that it's using a Bosch OBC and it also does not seem to randomise the MAC addresses.
10:BD:43 is assigned to Robert Bosch Elektronikai Kft.