### PR TITLE
web/charge-limits: Remove debug log message

### DIFF
--- a/software/web/src/modules/charge_limits/main.tsx
+++ b/software/web/src/modules/charge_limits/main.tsx
@@ -253,7 +253,6 @@ export class ChargeLimitsStatus extends Component<{}, {last_custom_energy: numbe
 
                 if (config_in_use.soc_pct != 0) {
                     soc_placeholder = config_in_use.soc_pct + " %";
-                    console.log(ev_soc);
                     if (ev_soc != null) { // ev_soc is NaN. NaN is serialized as null in JSON.
                         soc_placeholder += " | " + __("charge_limits.content.soc_currently") + " " + util.toLocaleFixed(ev_soc, 0) + " %";
                     }


### PR DESCRIPTION
I was stumbling over https://github.com/Tinkerforge/esp32-firmware/commit/bef2b2e0d853fc35b161c8ffb0e40de48ebdcf74 in 2.12.2 and while searching for that I saw this stray debug line in my console all the time.